### PR TITLE
Fix sorting order

### DIFF
--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -11,6 +11,7 @@ import { IncomingMessage } from 'http';
 
 interface Member {
   last_star_ts: number;
+  local_score: number;
   stars: number;
   name: string;
 }
@@ -118,12 +119,8 @@ export default class Leaderboard {
     // convert from object to array
     let members: Member[] = Object.values(leaderboardData.members);
 
-    // sort for star amount and last star timestamp
-    members.sort((a: Member, b: Member): number => {
-      if (a.last_star_ts === 0) a.last_star_ts += 9999999999;
-      if (b.last_star_ts === 0) b.last_star_ts += 9999999999;
-      return b.stars - a.stars + a.last_star_ts - b.last_star_ts;
-    });
+    // sort based on local score
+    members.sort((a: Member, b: Member): number => b.local_score - a.local_score);
 
     // add members to embed
     for (const member of members) {

--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -120,7 +120,10 @@ export default class Leaderboard {
     let members: Member[] = Object.values(leaderboardData.members);
 
     // sort based on local score
-    members.sort((a: Member, b: Member): number => b.local_score - a.local_score);
+    members.sort((a: Member, b: Member): number => {
+      if (b.stars !== a.stars) return b.stars - a.stars;
+      else return b.local_score - a.local_score;
+    });
 
     // add members to embed
     for (const member of members) {


### PR DESCRIPTION
```ts
    // sort for star amount and last star timestamp
    members.sort((a: Member, b: Member): number => {
      if (a.last_star_ts === 0) a.last_star_ts += 9999999999;
      if (b.last_star_ts === 0) b.last_star_ts += 9999999999;
      return b.stars - a.stars + a.last_star_ts - b.last_star_ts;
    });
```
This initial sorting order has some problems: 
* It differs from the one on [adventofcode.com](https://adventofcode.com/2020/leaderboard/private/view/670567)  
* It mainly depends on the time of the last commit as amount of stars is pretty small compared to the size of the timestamp

I had two attempts to fixing this, the first one was basing the order solely on the local_score, just as the leaderboard normaly does.

@LeMoonStar made the point that this order is quite unfair for those who have to start later and therefore can't compete with high local scores. 
Therefore the ranking is now primarily based on the amount of stars and if it is equal falls back to the local score.

Pick whatever is prefered.

⚠️**I wasn't able to test this so use with caution**