### PR TITLE
reused this._now instead of creating new Date object

### DIFF
--- a/src/ChannelUpdater.ts
+++ b/src/ChannelUpdater.ts
@@ -60,7 +60,7 @@ export default class ChannelUpdater {
           .setTimestamp(new Date())
           .setTitle('Advent of Code')
           .setDescription(
-            `New day, new challenge! Visit the [Advent of Code website day ${today}](https://adventofcode.com/2020/day/${new Date().getDate()})`
+            `New day, new challenge! Visit the [Advent of Code website day ${today}](https://adventofcode.com/2020/day/${this._now.getDate()})`
           )
       );
     }


### PR DESCRIPTION
in an attempt to fix the wrong day number in the link sent by the bot each new day, @TrojanerHD replaced the use of `this._now` with a `new Date()` which later turned out not to fix the problem, instead, the fix was (#3) to use `Date.getDate()` instead of `Date.getDay()`, tough with the actual fix, the use of `new Date()` was continued which is an unnecessary use of resources. 