### PR TITLE
Ignore all leaderboard members with 0 stars

### DIFF
--- a/src/ChannelUpdater.ts
+++ b/src/ChannelUpdater.ts
@@ -1,7 +1,13 @@
-import { CategoryChannel, Guild, GuildChannel, MessageEmbed, TextChannel } from 'discord.js';
+import {
+  CategoryChannel,
+  GuildChannel,
+  MessageEmbed,
+  TextChannel,
+} from 'discord.js';
 import DiscordBot from './DiscordBot';
 
 export default class ChannelUpdater {
+  private _now: Date = new Date();
   constructor() {
     DiscordBot._client.on('ready', this.onReady.bind(this));
   }
@@ -11,20 +17,20 @@ export default class ChannelUpdater {
   }
 
   private checkToday(): void {
-    const now: Date = new Date();
+    this._now.setHours(this._now.getHours() - 6); // Because the bot is hosted on a server with CET time zone…
     const nextDay: Date = new Date(
-      now.getFullYear(),
-      now.getMonth(),
-      now.getDate(),
-      6, // Because the bot is hosted on a server with CET time zone…
+      this._now.getFullYear(),
+      this._now.getMonth(),
+      this._now.getDate(),
+      6,
       0,
       0,
       0
     );
-    nextDay.setDate(now.getDate() + 1);
+    nextDay.setDate(this._now.getDate() + 1);
     setTimeout(
       this.checkToday.bind(this),
-      nextDay.getTime() - now.getTime()
+      nextDay.getTime() - this._now.getTime()
     );
     for (const guild of DiscordBot._client.guilds.cache.array()) {
       const soonChannel:
@@ -41,8 +47,7 @@ export default class ChannelUpdater {
       const todayChannel: GuildChannel | undefined = (<CategoryChannel>(
         soonChannel
       )).children.find(
-        (channel: GuildChannel) =>
-          channel.name.toLowerCase() === today
+        (channel: GuildChannel) => channel.name.toLowerCase() === today
       );
       if (!todayChannel) continue;
       todayChannel
@@ -56,13 +61,19 @@ export default class ChannelUpdater {
           )
         )
         .catch(console.error);
-        (<TextChannel> todayChannel).send(new MessageEmbed().setTimestamp(new Date()).setTitle('Advent of Code').setDescription(`New day, new challenge! Visit the [Advent of Code website day ${today}](Insert url here)`))
+      (<TextChannel>todayChannel).send(
+        new MessageEmbed()
+          .setTimestamp(new Date())
+          .setTitle('Advent of Code')
+          .setDescription(
+            `New day, new challenge! Visit the [Advent of Code website day ${today}](https://adventofcode.com/2020/day/${this._now.getDay()})`
+          )
+      );
     }
   }
 
   private parseDay(): string {
-    const date: Date = new Date();
-    let day: string = date.getDate().toString();
-    return date.getDate() < 10 ? `0${day}` : day;
+    let day: string = this._now.getDate().toString();
+    return this._now.getDate() < 10 ? `0${day}` : day;
   }
 }

--- a/src/ChannelUpdater.ts
+++ b/src/ChannelUpdater.ts
@@ -67,7 +67,7 @@ export default class ChannelUpdater {
           .setTimestamp(new Date())
           .setTitle('Advent of Code')
           .setDescription(
-            `New day, new challenge! Visit the [Advent of Code website day ${today}](https://adventofcode.com/2020/day/${this._now.getDay()})`
+            `New day, new challenge! Visit the [Advent of Code website day ${today}](https://adventofcode.com/2020/day/${new Date().getDay()})`
           )
       );
     }

--- a/src/ChannelUpdater.ts
+++ b/src/ChannelUpdater.ts
@@ -17,6 +17,7 @@ export default class ChannelUpdater {
   }
 
   private checkToday(): void {
+    this._now = new Date();
     this._now.setHours(this._now.getHours() - 6); // Because the bot is hosted on a server with CET time zone…
     const nextDay: Date = new Date(
       this._now.getFullYear(),

--- a/src/ChannelUpdater.ts
+++ b/src/ChannelUpdater.ts
@@ -48,7 +48,7 @@ export default class ChannelUpdater {
       const todayChannel: GuildChannel | undefined = (<CategoryChannel>(
         soonChannel
       )).children.find(
-        (channel: GuildChannel) => channel.name.toLowerCase() === today
+        (channel: GuildChannel) => channel.name.toLowerCase() === `${this._now.getFullYear()}-${today}`
       );
       if (!todayChannel) continue;
       todayChannel

--- a/src/ChannelUpdater.ts
+++ b/src/ChannelUpdater.ts
@@ -23,7 +23,7 @@ export default class ChannelUpdater {
       this._now.getFullYear(),
       this._now.getMonth(),
       this._now.getDate(),
-      6,
+      0,
       0,
       0,
       0

--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -23,10 +23,10 @@ export default class Leaderboard {
     // get all guilds the bot is on
     for (const guild of DiscordBot._client.guilds.cache.array()) {
       // check if these guilds have a text channel named 'leaderboard'
-      const leaderboardChannel = guild.channels.cache
+      const leaderboardChannel: GuildChannel = guild.channels.cache
         .array()
         .find(
-          (channel: GuildChannel) =>
+          (channel: GuildChannel): boolean =>
             channel.name === 'leaderboard' && channel.type === 'text'
         );
       if (!leaderboardChannel || !(leaderboardChannel instanceof TextChannel))
@@ -62,7 +62,7 @@ export default class Leaderboard {
             .setDescription('FIRST TIME SETUP...')
             .setTimestamp(now)
         )
-        .then((message: Message) => this._messages.push(message))
+        .then((message: Message): number => this._messages.push(message))
         .catch(console.error);
     }
 
@@ -77,7 +77,7 @@ export default class Leaderboard {
       1800000 //30 minutes
     );
 
-    const now = new Date();
+    const now: Date = new Date();
 
     console.log(`${now}: refreshing Leaderboard`);
 
@@ -90,7 +90,7 @@ export default class Leaderboard {
         }.json`,
         headers: { Cookie: `session=${process.env.AOC_SESSION}` },
       },
-      (res: IncomingMessage) => {
+      (res: IncomingMessage): void => {
         // wait for data
         res.on('data', this.dataReceived.bind(this));
       }
@@ -100,8 +100,8 @@ export default class Leaderboard {
   }
 
   private dataReceived(data: string): void {
-    const now = new Date();
-    const nextUpdate = new Date(now.getTime() + 1800000);
+    const now: Date = new Date();
+    const nextUpdate: Date = new Date(now.getTime() + 1800000);
     let leaderboardData: { members: Member[] } = JSON.parse(data);
 
     let newMsg: MessageEmbed = new MessageEmbed()
@@ -127,10 +127,10 @@ export default class Leaderboard {
 
     // add members to embed
     for (const member of members) {
-      let stars = '';
-      for (let i = 0; i < Math.floor(member.stars / 2); i++) stars += ':star:';
+      let stars: string = '';
+      for (let i: number = 0; i < Math.floor(member.stars / 2); i++) stars += ':star:';
       if (member.stars % 2) stars += ':last_quarter_moon:';
-      for (let i = Math.round(member.stars / 2); i < 24; i++)
+      for (let i: number = Math.round(member.stars / 2); i < 24; i++)
         stars += ':new_moon:';
 
       newMsg.addField(member.name, stars);

--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -127,6 +127,7 @@ export default class Leaderboard {
 
     // add members to embed
     for (const member of members) {
+      if (member.stars == 0) continue;
       let stars: string = '';
       for (let i: number = 0; i < Math.floor(member.stars / 2); i++) stars += ':star:';
       if (member.stars % 2) stars += ':last_quarter_moon:';


### PR DESCRIPTION
In some leaderboards, there are people from the past year, who don't play AoC anymore and therefore don't have any stars. It is not only taking up space on the Leaderboard in discord but also annoying when you need to scroll up more on small displays like mobile devices. Therefore users with no stars at all should not be displayed.