### PR TITLE
adding sorting to star list in leaderboard

### DIFF
--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -9,7 +9,39 @@ import DiscordBot from './DiscordBot';
 import { request } from 'https';
 import { IncomingMessage } from 'http';
 
+
+interface Day {
+  1: { get_star_ts: string};
+  2?: { get_star_ts: string};
+}
 interface Member {
+  completion_day_level: {
+    1?: Day;
+    2?: Day;
+    3?: Day;
+    4?: Day;
+    5?: Day;
+    6?: Day;
+    7?: Day;
+    8?: Day;
+    9?: Day;
+    10?: Day;
+    11?: Day;
+    12?: Day;
+    13?: Day;
+    14?: Day;
+    15?: Day;
+    16?: Day;
+    17?: Day;
+    18?: Day;
+    19?: Day;
+    20?: Day;
+    21?: Day;
+    22?: Day;
+    23?: Day;
+    24?: Day;
+    25?: Day;
+  };
   last_star_ts: number;
   local_score: number;
   stars: number;


### PR DESCRIPTION
Sorting the stars in the leaderboard has a few advantages over just displaying the star amount:
+ Higher information density. i.e. you don't only see how many stars someone has, but also what days they got them on and where they are stuck
+ It resembles the online leaderboard more closely