### PR TITLE
use different stars for different conditions

### DIFF
--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -166,10 +166,18 @@ export default class Leaderboard {
         if (i in member.completion_day_level) {
           if (member.completion_day_level[i][2]){
             // part 1 and 2 are complete
+            const completed_ts: number = Number(member.completion_day_level[i][2].get_star_ts)*1000;
+
             // check if star is younger than an hour
-            if (Number(member.completion_day_level[i][2].get_star_ts) - (now.getTime()/1000 - 3600/*one hour*/) > 0){
-              stars += ':star2:'; // star is younger than one hour
-            } else stars += ':star:'; // star is older than one hour
+            if (completed_ts - (now.getTime() - 3600000/*one hour*/) > 0){
+              // star is younger than one hour
+              stars += ':star2:';
+              
+            } else if(completed_ts-10800000 < this.getDay(now, i).getTime()) { //TODO: this doesn't work
+              // member completed day in under 3 hours
+              stars += ':sparkles:';
+            }
+            else stars += ':star:'; // star is older than one hour and was not completet inside the 3 hours after release
           }
           else stars += ':last_quarter_moon:';  // part 1 is complete, but not part 2
           continue;
@@ -182,5 +190,9 @@ export default class Leaderboard {
 
     // update all leaderbaord messages
     for (const msg of this._messages) msg.edit(newMsg).catch(console.error);
+  }
+
+  private getDay(now: Date, day: number): Date {
+    return new Date(`${now.getFullYear()}-12-${("0" + day).slice(-2)}T00:00:00-05:00`);
   }
 }

--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -173,7 +173,7 @@ export default class Leaderboard {
               // star is younger than one hour
               stars += ':star2:';
               
-            } else if(completed_ts-10800000 < this.getDay(now, i).getTime()) { //TODO: this doesn't work
+            } else if(completed_ts-10800000 < this.getDateOfChallengeBegin(now, i).getTime()) {
               // member completed day in under 3 hours
               stars += ':sparkles:';
             }
@@ -192,7 +192,7 @@ export default class Leaderboard {
     for (const msg of this._messages) msg.edit(newMsg).catch(console.error);
   }
 
-  private getDay(now: Date, day: number): Date {
+  private getDateOfChallengeBegin(now: Date, day: number): Date {
     return new Date(`${now.getFullYear()}-12-${("0" + day).slice(-2)}T00:00:00-05:00`);
   }
 }

--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -164,7 +164,13 @@ export default class Leaderboard {
 
       for (let i = 1; i < 26; i++) {
         if (i in member.completion_day_level) {
-          if (member.completion_day_level[i][2]) stars += ':star:'; // part 1 and 2 are complete
+          if (member.completion_day_level[i][2]){
+            // part 1 and 2 are complete
+            // check if star is younger than an hour
+            if (Number(member.completion_day_level[i][2].get_star_ts) - (now.getTime()/1000 - 3600/*one hour*/) > 0){
+              stars += ':star2:'; // star is younger than one hour
+            } else stars += ':star:'; // star is older than one hour
+          }
           else stars += ':last_quarter_moon:';  // part 1 is complete, but not part 2
           continue;
         }


### PR DESCRIPTION
## Description
Using :star2: instead of :star: on any day where the solution to part 2 is younger than one hour makes the Leaderboard not only more beautiful but also shows the small achievements of each and every player better. The even bigger achievement of finishing a complete day in under 3 hours after the release of the task is also rewarded using :sparkles: as permanent emoji for this day.
## Example Image
### new completions
![image](https://user-images.githubusercontent.com/24989169/101248892-600d5d80-371d-11eb-9f6b-991d6980d858.png)
### days finished in under 3 hours
![image](https://user-images.githubusercontent.com/24989169/101262869-e8055e80-3741-11eb-9f86-5ea9b2f23cb1.png)

## TODO:
- [x] use :star2: instead of :star: when the day was completed less than an hour ago
- [x] use :sparkles: when the day was completed in under 3 hours after the release of the challange