### PR TITLE
adding SQLite to save data on a server to server basis

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "author": "Trojaner",
   "license": "MIT",
   "dependencies": {
-    "@types/sqlite3": "^3.1.6",
     "discord.js": "^12.3.1",
     "sqlite3": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.11.10",
+    "@types/sqlite3": "^3.1.6",
     "dotenv": "^8.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "author": "Trojaner",
   "license": "MIT",
   "dependencies": {
-    "discord.js": "^12.3.1"
+    "@types/sqlite3": "^3.1.6",
+    "discord.js": "^12.3.1",
+    "sqlite3": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.11.10",

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -11,7 +11,7 @@ export interface ServerInfo {
 }
 
 export default class DatabaseHelper {
-  public _db: Database;
+  private _db: Database;
 
   constructor(file: string, callback?: ()=>void) {
     this._db = new Database(file);

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -1,7 +1,7 @@
 import { Server } from 'http';
 import { Database, RunResult, Statement } from 'sqlite3';
 
-export default interface ServerInfo {
+export interface ServerInfo {
   id: string;
   enableleaderboard: boolean;
   enableChannelUpdater: boolean;
@@ -27,7 +27,7 @@ export default class DatabaseHelper {
   public getServer(id: string): Promise<ServerInfo> {
     return new Promise<ServerInfo>((resolve, reject) => {
       this.getRow(`SELECT * FROM servers WHERE id=?;`, [id])
-        .then((row) => {
+        .then((row: any) => {
           resolve(row);
         })
         .catch(reject);
@@ -63,7 +63,7 @@ export default class DatabaseHelper {
         ]
       )
         .then(resolve)
-        .catch((err) => reject(err));
+        .catch((err: Error) => reject(err));
     });
   }
 

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -21,8 +21,7 @@ export default class DatabaseHelper {
 
   /**
    * Gets a server's configuration from the database
-   * @param id the Gulid ID to identifie the rows
-   *
+   * @param id the Guild ID to identify the rows
    * @returns a promise of a ServerInfo interface containing all of the row's data
    */
   public getServer(id: string): Promise<ServerInfo> {
@@ -69,8 +68,8 @@ export default class DatabaseHelper {
   }
 
   /**
-   * Creates all reuqired tables if they don't exist.
-   * @returns a void promise, for error andling only
+   * Creates all required tables if they don't exist.
+   * @returns a void promise, for error handling only
    */
   private initDatabase(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -95,8 +94,8 @@ export default class DatabaseHelper {
   /**
    * A wrapper around the Database.run function of the sqlite3 library
    * @param sql the SQL query to be executed
-   * @param params parameters for placeholders. automatically sanitized.
-   * @returns a void promise, for error andling only
+   * @param params parameters for placeholders. Automatically sanitized
+   * @returns a void promise, for error handling only
    */
   private runQuery(sql: string, params: any[]): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -110,8 +109,8 @@ export default class DatabaseHelper {
   /**
    * A wrapper around the Database.get function of the sqlite3 library
    * @param sql the SQL query to be executed
-   * @param params parameters for placeholders. automatically sanitized.
-   * @returns a promise for a any object, containing the data of the row the query fetched.
+   * @param params parameters for placeholders. Automatically sanitized
+   * @returns a promise for an any object containing the data of the row the query fetched
    */
   private getRow(sql: string, params: any[]): Promise<any> {
     return new Promise((resolve, reject) => {
@@ -125,8 +124,8 @@ export default class DatabaseHelper {
   /**
    * A wrapper around the Database.all function of the sqlite3 library
    * @param sql the SQL query to be executed
-   * @param params parameters for placeholders. automatically sanitized.
-   * @returns a promise for an any array, containing all rows the query fetched.
+   * @param params parameters for placeholders. Automatically sanitized
+   * @returns a promise for an any array containing all rows the query fetched
    */
   private getAllRows(sql: string, params: any[]): Promise<any[]> {
     return new Promise((resolve, reject) => {

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -120,7 +120,7 @@ export default class DatabaseHelper {
    * @returns a void promise, for error handling only
    */
   private runQuery(sql: string, params: any[]): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       this._db.run(sql, params, (err: Error) => {
         if (err) reject(err);
         resolve();
@@ -135,7 +135,7 @@ export default class DatabaseHelper {
    * @returns a promise for an any object containing the data of the row the query fetched
    */
   private getRow(sql: string, params: any[]): Promise<any> {
-    return new Promise((resolve, reject) => {
+    return new Promise<any>((resolve, reject) => {
       this._db.get(sql, params, (err: Error, row: any) => {
         if (err) reject(err);
         resolve(row);
@@ -150,7 +150,7 @@ export default class DatabaseHelper {
    * @returns a promise for an any array containing all rows the query fetched
    */
   private getAllRows(sql: string, params: any[]): Promise<any[]> {
-    return new Promise((resolve, reject) => {
+    return new Promise<any[]>((resolve, reject) => {
       this._db.all(sql, params, (err: Error, rows: any[]) => {
         if (err) reject(err);
         resolve(rows);

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -98,13 +98,13 @@ export default class DatabaseHelper {
       this.runQuery(
         `
         CREATE TABLE IF NOT EXISTS servers (
-          id INTEGER NOT NULL PRIMARY KEY,
-          enableLeaderboard INTEGER NOT NULL DEFAULT 0,
-          enableChannelUpdater INTEGER NOT NULL DEFAULT 0,
-          aocSession Text,
+          id VARCHAR(20) NOT NULL PRIMARY KEY,
+          enableLeaderboard BOOLEAN NOT NULL DEFAULT 0,
+          enableChannelUpdater BOOLEAN NOT NULL DEFAULT 0,
+          aocSession VARCHAR(100),
           aocLeaderboardID INTEGER,
-          channelNamePattern TEXT,
-          categortyNamePattern TEXT
+          channelNamePattern VARCHAR(50),
+          categortyNamePattern VARCHAR(50)
         );`,
         []
       )

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -1,5 +1,4 @@
-import { Server } from 'http';
-import { Database, RunResult, Statement } from 'sqlite3';
+import { Database, RunResult } from 'sqlite3';
 
 export interface ServerInfo {
   id: string;

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -20,8 +20,8 @@ export default class DatabaseHelper {
 
   /**
    * Gets a server's configuration from the database
-   * @param id the Guild ID to identify the rows
-   * @returns a promise of a ServerInfo interface containing all of the row's data
+   * @param id The Guild ID to identify the rows
+   * @returns A promise of a ServerInfo interface containing all of the row's data
    */
   public getServer(id: string): Promise<ServerInfo> {
     return new Promise<ServerInfo>((resolve, reject) => {
@@ -40,10 +40,10 @@ export default class DatabaseHelper {
   }
 
   /**
-   * updates data in the database. the row to be updated is choosen from the ID in the data object.
-   * If no row with the provided id exists, creates a new one
-   * @param data a ServerInfo object containing the data to be written.
-   * @returns a void promise, for error andling only
+   * Updates data in the database. The row to be updated is chosen from the ID in the data object.
+   * Creates a new row if no row with the provided id exists
+   * @param data A ServerInfo object containing the data to be written.
+   * @returns A void promise, for error handling only
    */
   public updateServer(data: ServerInfo): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -91,7 +91,7 @@ export default class DatabaseHelper {
 
   /**
    * Creates all required tables if they don't exist.
-   * @returns a void promise, for error handling only
+   * @returns A void promise, for error handling only
    */
   private initDatabase(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -115,9 +115,9 @@ export default class DatabaseHelper {
 
   /**
    * A wrapper around the Database.run function of the sqlite3 library
-   * @param sql the SQL query to be executed
-   * @param params parameters for placeholders. Automatically sanitized
-   * @returns a void promise, for error handling only
+   * @param sql The SQL query to be executed
+   * @param params Parameters for placeholders. Automatically sanitized
+   * @returns A void promise, for error handling only
    */
   private runQuery(sql: string, params: any[]): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -130,9 +130,9 @@ export default class DatabaseHelper {
 
   /**
    * A wrapper around the Database.get function of the sqlite3 library
-   * @param sql the SQL query to be executed
-   * @param params parameters for placeholders. Automatically sanitized
-   * @returns a promise for an any object containing the data of the row the query fetched
+   * @param sql The SQL query to be executed
+   * @param params Parameters for placeholders. Automatically sanitized
+   * @returns A promise for an any object containing the data of the row the query fetched
    */
   private getRow(sql: string, params: any[]): Promise<any> {
     return new Promise<any>((resolve, reject) => {
@@ -145,9 +145,9 @@ export default class DatabaseHelper {
 
   /**
    * A wrapper around the Database.all function of the sqlite3 library
-   * @param sql the SQL query to be executed
-   * @param params parameters for placeholders. Automatically sanitized
-   * @returns a promise for an any array containing all rows the query fetched
+   * @param sql The SQL query to be executed
+   * @param params Parameters for placeholders. Automatically sanitized
+   * @returns A promise for an any array containing all rows the query fetched
    */
   private getAllRows(sql: string, params: any[]): Promise<any[]> {
     return new Promise<any[]>((resolve, reject) => {

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -1,0 +1,139 @@
+import { Server } from 'http';
+import { Database, RunResult, Statement } from 'sqlite3';
+
+export default interface ServerInfo {
+  id: string;
+  enableleaderboard: boolean;
+  enableChannelUpdater: boolean;
+  aocSession: string;
+  aocLeaderboardID: number;
+  channelNamePattern: string;
+  categoryNamePattern: string;
+}
+
+export default class DatabaseHelper {
+  public db: Database;
+
+  constructor(file: string) {
+    this.db = new Database(file);
+    this.initDatabase();
+  }
+
+  /**
+   * Gets a server's configuration from the database
+   * @param id the Gulid ID to identifie the rows
+   *
+   * @returns a promise of a ServerInfo interface containing all of the row's data
+   */
+  public getServer(id: string): Promise<ServerInfo> {
+    return new Promise<ServerInfo>((resolve, reject) => {
+      this.getRow(`SELECT * FROM servers WHERE id=?;`, [id])
+        .then((row) => {
+          resolve(row);
+        })
+        .catch(reject);
+    });
+  }
+
+  /**
+   * updates data in the database. the row to be updated is choosen from the ID in the data object.
+   * If no row with the provided id exists, creates a new one
+   * @param data a ServerInfo object containing the data to be written.
+   * @returns a void promise, for error andling only
+   */
+  public updateServer(data: ServerInfo): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.runQuery(
+        `
+        UPDATE servers SET
+        enableLeaderboard=?,
+        enableChannelUpdater=?,
+        aocSession=?,
+        aocLeaderboardID=?,
+        channelNamePattern=?,
+        categortyNamePattern=?
+        WHERE id=?;`,
+        [
+          data.enableleaderboard,
+          data.enableChannelUpdater,
+          data.aocSession,
+          data.aocLeaderboardID,
+          data.channelNamePattern,
+          data.categoryNamePattern,
+          data.id,
+        ]
+      )
+        .then(resolve)
+        .catch((err) => reject(err));
+    });
+  }
+
+  /**
+   * Creates all reuqired tables if they don't exist.
+   * @returns a void promise, for error andling only
+   */
+  private initDatabase(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.runQuery(
+        `
+        CREATE TABLE IF NOT EXISTS servers (
+          id INTEGER NOT NULL PRIMARY KEY,
+          enableLeaderboard INTEGER NOT NULL DEFAULT 0,
+          enableChannelUpdater INTEGER NOT NULL DEFAULT 0,
+          aocSession Text,
+          aocLeaderboardID INTEGER,
+          channelNamePattern TEXT,
+          categortyNamePattern TEXT
+        );`,
+        []
+      )
+        .then(resolve)
+        .catch(reject);
+    });
+  }
+
+  /**
+   * A wrapper around the Database.run function of the sqlite3 library
+   * @param sql the SQL query to be executed
+   * @param params parameters for placeholders. automatically sanitized.
+   * @returns a void promise, for error andling only
+   */
+  private runQuery(sql: string, params: any[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.db.run(sql, params, (result: RunResult, err: Error) => {
+        if (err) reject(err);
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * A wrapper around the Database.get function of the sqlite3 library
+   * @param sql the SQL query to be executed
+   * @param params parameters for placeholders. automatically sanitized.
+   * @returns a promise for a any object, containing the data of the row the query fetched.
+   */
+  private getRow(sql: string, params: any[]): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.db.get(sql, params, (err: Error, row: any) => {
+        if (err) reject(err);
+        resolve(row);
+      });
+    });
+  }
+
+  /**
+   * A wrapper around the Database.all function of the sqlite3 library
+   * @param sql the SQL query to be executed
+   * @param params parameters for placeholders. automatically sanitized.
+   * @returns a promise for an any array, containing all rows the query fetched.
+   */
+  private getAllRows(sql: string, params: any[]): Promise<any[]> {
+    return new Promise((resolve, reject) => {
+      this.db.all(sql, params, (err: Error, rows: any[]) => {
+        if (err) reject(err);
+        resolve(rows);
+      });
+    });
+  }
+}

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -13,9 +13,9 @@ export interface ServerInfo {
 export default class DatabaseHelper {
   public _db: Database;
 
-  constructor(file: string) {
+  constructor(file: string, callback?: ()=>void) {
     this._db = new Database(file);
-    this.initDatabase().catch(console.error);
+    this.initDatabase().then(callback).catch(console.error);
   }
 
   /**

--- a/src/DatabaseHelper.ts
+++ b/src/DatabaseHelper.ts
@@ -12,10 +12,10 @@ export default interface ServerInfo {
 }
 
 export default class DatabaseHelper {
-  public db: Database;
+  public _db: Database;
 
   constructor(file: string) {
-    this.db = new Database(file);
+    this._db = new Database(file);
     this.initDatabase();
   }
 
@@ -100,7 +100,7 @@ export default class DatabaseHelper {
    */
   private runQuery(sql: string, params: any[]): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.db.run(sql, params, (result: RunResult, err: Error) => {
+      this._db.run(sql, params, (result: RunResult, err: Error) => {
         if (err) reject(err);
         resolve();
       });
@@ -115,7 +115,7 @@ export default class DatabaseHelper {
    */
   private getRow(sql: string, params: any[]): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.db.get(sql, params, (err: Error, row: any) => {
+      this._db.get(sql, params, (err: Error, row: any) => {
         if (err) reject(err);
         resolve(row);
       });
@@ -130,7 +130,7 @@ export default class DatabaseHelper {
    */
   private getAllRows(sql: string, params: any[]): Promise<any[]> {
     return new Promise((resolve, reject) => {
-      this.db.all(sql, params, (err: Error, rows: any[]) => {
+      this._db.all(sql, params, (err: Error, rows: any[]) => {
         if (err) reject(err);
         resolve(rows);
       });


### PR DESCRIPTION
(Resolves #12) Using SQLite is one way to save the configuration on a (discord) server to (discord) server basis, and better suited than a JSON file for this use case. This Branch will be used to implement a helper class to save data for each (discord) server and therefore the configuration of each (discord) server containing the AoC Session, the AoC leaderboard ID, naming patterns for the channel updater and more general settings.

## Database structure
(for any change requests or suggestions, please write a comment)
currently, only one table (and thus also it's corresponding TypeScript interface) is planned:
### Table `servers`
| name | type | flags | description | required by |
|---|---|---|---|---|
| id | VARCHAR(20) | NOT NULL PRIMARY KEY | the Guild ID of the discord server | * |
| enableLeaderboard | BOOLEAN |  NOT NULL DEFAULT 0 | whether the leaderboard feature should be enabled on this server  | leaderboard |
| enableChannelUpdater | BOOLEAN |  NOT NULL DEFAULT 0 | whether the channel updater feature should be enabled for this server | ChannelUpdater |
| aocSession | VARCHAR(100) |  | the session-id the discord server owner specified and is used to make requests to the API for this server | leaderboard |
| aocLeaderboardID | INTEGER |  | if specified the id of the leaderboard | leaderboard |
| channelNamePattern | VARCHAR(50) |  | the name format for day-specific channels  | ChannelUpdater |
| categortyNamePattern | VARCHAR(50) |  | the name format for year-specific category  | ChannelUpdater |
#### SQL:
```sql
CREATE TABLE IF NOT EXISTS servers (
  id VARCHAR(20) NOT NULL PRIMARY KEY,
  enableLeaderboard BOOLEAN NOT NULL DEFAULT 0,
  enableChannelUpdater BOOLEAN NOT NULL DEFAULT 0,
  aocSession VARCHAR(100),
  aocLeaderboardID INTEGER,
  channelNamePattern VARCHAR(50),
  categortyNamePattern VARCHAR(50)
);
```

## How to use
The DatabaseHelper class provides functions so simply save and use server information in the form of the `ServerInfo` interface
### Opening a database
To open an SQLite file, you just have to construct a new `DatabaseHelper` with a file path as the first argument, the second argument can be a callback which is called when the database was successfully initialized. 
```ts
import DatabaseHelper from './DatabaseHelper';

const db = new Databasehelper('file.sqlite');
```

### Reading data
To read data you simply provide the server guild ID to the `DatabaseHelper::getServer(id: string): Promise<ServerInfo>` function, this will return a promise for a ServerInfo object.
```ts
import DatabaseHelper from './DatabaseHelper';

const db = new Databasehelper('file.sqlite', callback);

function callback(): void {
  db.getServer('11234567890123').then((server) => {
    console.log(server);
  }).catch(console.error);
}
```

### Writing data
Writing data can be accomplished using the `DatabaseHelper::updateServer(data: ServerInfo): Promise<void>` function, it will either create a row if the id from the ServerInfo object is not found or update the row with the data. 
```
import DatabaseHelper from './DatabaseHelper';

const data: ServerInfo = {
  id: '1234567890123',
  enableleaderboard: true,
  enableChannelUpdater: true
};

const db = new Databasehelper('file.sqlite', callback);

function callback(): void {
  db.updateServer(data).catch(console.error);
}
```

## TODO

+ [x] Fix write access to the Database (fixed with 3139b6fb537bf3b9036eb777ea44fab91bf2f369)
   ~~maybe `Database.exec()` is required instead of `Database.run()` to perform these actions. (needs to be tested)~~
  + [x] (problem) The `initDatabase` function doesn't create the table
  + [x] (problem) The `updateServer` function doesn't update servers
+ [x] migrate to more general SQL datatypes (0df232fe8cf94c644e18b0372a0e778b80dbf9dd)
+ [x] using the helper class on a new file and trying to access data directly after construction results in an error because the table which's creation is asynchronous hast yet been created. solution: add callback argument to constructor (d25d88806a44da9c73308498cd896f2bf5d839bd)