### PR TITLE
 Change bot's deployment to docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: build
+
+on:
+  workflow_run:
+    workflows:
+      - TypeScript compilation
+    branches: [main]
+    types:
+      - completed
+      
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ghcr.io/trojanerhd/adventofcode-bot:latest

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and compile it to typescript
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: TypeScript compilation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 17.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install packages
+        run: yarn
+      - name: Typescript compiler
+        uses: iCrawl/action-tsc@v1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
                 "${workspaceFolder}/**/*.js"
             ],
             "preLaunchTask": "tsc: build - tsconfig.json",
-            "runtimeArgs": ["-r", "dotenv/config", "--trace-warnings"],
+            "runtimeArgs": ["--trace-warnings"],
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:lts-alpine
+
+# create and set workdir
+WORKDIR /usr/src/trojaner
+
+# install dependencies 
+COPY package.json ./
+COPY yarn.lock ./
+RUN yarn install --frozen-lockfile
+RUN yarn global add typescript
+
+# copy bot to work dir
+COPY . ./
+
+RUN tsc
+
+# main command
+CMD ["node", "build/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yarn global add typescript
 # copy bot to work dir
 COPY . ./
 
-RUN tsc
+RUN yarn compile
 
 # main command
 CMD ["node", "build/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  adventofcode-bot:
+    build:
+      dockerfile: ./Dockerfile
+    env_file: .env
+    volumes:
+      - adventofcode-bot:/usr/src/trojaner
+    ports:
+      - "3334:80"
+
+volumes:
+  adventofcode-bot:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "typescript": "^4.4.4"
   },
   "scripts": {
-    "compile": "tsc -p ."
+    "compile": "tsc"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 import DiscordBot from './DiscordBot';
+import dotenv from 'dotenv';
+
+// Load dotenv config
+dotenv.config();
 
 new DiscordBot();


### PR DESCRIPTION
Basically the same change as was done in https://github.com/TrojanerHD/TrojanerBot/pull/83 (and also updates a bit of outdated practices / code as side effects)

Changes the deployment of this bot to docker so a docker container is pushed after each commit on main if no typescript issues were found.