### PR TITLE
Fix long timeout for leaderboard in the first hours of the first day

### DIFF
--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -159,9 +159,10 @@ export default class Leaderboard {
 
   private updateLeaderboard(): void {
     const now: Date = new Date();
-    this.#nextUpdate = aocTime(now)
-      ? 1800000 // 30 minutes
-      : 24 * 60 * 60 * 1000; // 24 hours
+    const oneDay: number = 24 * 60 * 60 * 1000;
+    this.#nextUpdate = aocTime(now) || aocTime(new Date(now.getTime() + oneDay))
+      ? 1_800_000 // 30 minutes
+      : oneDay; // 24 hours
     // re-call this function in 30 minutes if it's Advent of Code, otherwise in 24 hours
     setTimeout(this.updateLeaderboard.bind(this), this.#nextUpdate);
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -31,5 +31,9 @@ export function send(
  * @returns Whether the date is in the Advent of Code time
  */
 export function aocTime(date: Date): boolean {
-  return date.getMonth() === 11 && date.getDate() <= 25;
+  return (
+    date.getMonth() === 11 &&
+    date.getDate() <= 25 &&
+    (date.getDate() !== 1 || date.getUTCHours() >= 5)
+  );
 }


### PR DESCRIPTION
Previously, we only checked if it is aoc time right now, and if not make the leaderboard timeout 24hrs. This PR adds a check if in at most 24hrs AoC starts and if so, applies the shorter timeout of 30 minutes already.

Also, the AoC time check is now more precise to match the hour