### PR TITLE
Set number of days in 2025 to 12

### DIFF
--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -9,7 +9,7 @@ import {
 } from 'discord.js';
 import DiscordBot from './DiscordBot';
 import { request } from 'https';
-import { aocTime, parseDay, send } from './common';
+import { aocTime, numberOfDays, parseDay, send } from './common';
 import * as fs from 'fs';
 import { IncomingMessage } from 'http';
 
@@ -243,7 +243,7 @@ export default class Leaderboard {
       if (member.stars === 0) continue;
       let stars: string = '';
 
-      for (let i = 1; i < 26; i++) {
+      for (let i = 1; i <= numberOfDays(now.getFullYear()); i++) {
         if (i in member.completion_day_level) {
           if (member.completion_day_level[i as AdventDay]![2]) {
             // part 1 and 2 are complete

--- a/src/common.ts
+++ b/src/common.ts
@@ -26,14 +26,24 @@ export function send(
 }
 
 /**
- * Checks if given date is in the Advent of Code time (between Dec 1 and Dec 25)
+ * Checks if given date is in the Advent of Code time
+ * (between Dec 1 and Dec 25 for 2024 or earlier and between Dec 1 and Dec 12 for 2025 or later)
  * @param date The date to check
  * @returns Whether the date is in the Advent of Code time
  */
 export function aocTime(date: Date): boolean {
   return (
     date.getMonth() === 11 &&
-    date.getDate() <= 25 &&
+    date.getDate() <= numberOfDays(date.getFullYear())&&
     (date.getDate() !== 1 || date.getUTCHours() >= 5)
   );
+}
+
+/**
+ * Returns the number of days of challenges for the current year
+ * @param year The year to check
+ * @returns The amount of days for the specified year
+ */
+export function numberOfDays(year: number): number {
+  return year <= 2024 ? 25 : 12;
 }


### PR DESCRIPTION
In 2025, the number of days with puzzles has been reduced to 12: https://adventofcode.com/2025/about#faq_num_days

This is updated in the code now.

Reviewers: please double-check whether I found every hard-code set to 25 days.